### PR TITLE
[WIP] add typescript path mapping sample for mixed web&rn

### DIFF
--- a/ts-mapping/native/native.tsx
+++ b/ts-mapping/native/native.tsx
@@ -1,0 +1,19 @@
+import { Card, List } from 'antd-mobile'
+import Flex from 'antd-mobile/lib/flex'
+
+const style = { color: 'white' }
+
+const card = (
+  <Card
+    onLayout={() => {}}
+    onTouchEnd={() => { }}
+  />
+)
+
+const list = () => (
+  <List
+    style={style}
+    onLayout={() => {}}
+    onTouchEnd={() => { }}
+  />
+)

--- a/ts-mapping/native/tsconfig.json
+++ b/ts-mapping/native/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "baseUrl": "../",
+    "paths": {
+      "antd-mobile": [
+        "./node_modules/antd-mobile/lib/native",
+        "./types/native"
+      ],
+      "antd-mobile/lib/*": [
+        "./node_modules/antd-mobile/lib/*"
+      ]
+    }
+  }
+}

--- a/ts-mapping/package.json
+++ b/ts-mapping/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ts-mapping",
+  "version": "0.1.0",
+  "license": "MIT",
+  "dependencies": {
+    "antd-mobile": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "latest",
+    "@types/react-native": "latest",
+    "tslint": "latest"
+  },
+  "scripts": {
+    "lint": "npm run lint:native && npm run lint:web",
+    "lint:native": "tslint --type-check -p native",
+    "lint:web": "tslint --type-check -p web"
+  }
+}

--- a/ts-mapping/package.json
+++ b/ts-mapping/package.json
@@ -10,10 +10,11 @@
   "devDependencies": {
     "@types/react": "latest",
     "@types/react-native": "latest",
-    "tslint": "latest"
+    "tslint": "latest",
+    "typescript": "latest"
   },
   "scripts": {
-    "lint": "npm run lint:native && npm run lint:web",
+    "lint": "npm run lint:native & npm run lint:web",
     "lint:native": "tslint --type-check -p native",
     "lint:web": "tslint --type-check -p web"
   }

--- a/ts-mapping/tsconfig.json
+++ b/ts-mapping/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+    "jsx": "preserve",
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "allowSyntheticDefaultImports":true,
+    "target": "es6"
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "compileOnSave": false
+}

--- a/ts-mapping/types/native.tsx
+++ b/ts-mapping/types/native.tsx
@@ -1,0 +1,54 @@
+export { default as Accordion } from 'antd-mobile/lib/accordion';
+export { default as ActionSheet } from 'antd-mobile/lib/action-sheet';
+export { default as ActivityIndicator } from 'antd-mobile/lib/activity-indicator';
+export { default as Badge } from 'antd-mobile/lib/badge';
+export { default as Button } from 'antd-mobile/lib/button';
+export { default as Card } from 'antd-mobile/lib/card';
+export { default as Carousel } from 'antd-mobile/lib/carousel';
+export { default as Checkbox } from 'antd-mobile/lib/checkbox';
+export { default as DatePicker } from 'antd-mobile/lib/date-picker';
+export { default as Drawer } from 'antd-mobile/lib/drawer';
+export { default as Flex } from 'antd-mobile/lib/flex';
+export { default as Grid } from 'antd-mobile/lib/grid';
+export { default as Icon } from 'antd-mobile/lib/icon';
+export { default as ImagePicker } from 'antd-mobile/lib/image-picker';
+export { default as InputItem } from 'antd-mobile/lib/input-item';
+
+export { default as List } from 'antd-mobile/lib/list';
+export { default as ListView } from 'antd-mobile/lib/list-view';
+export { default as Menu } from 'antd-mobile/lib/menu';
+export { default as Modal } from 'antd-mobile/lib/modal';
+export { default as NavBar } from 'antd-mobile/lib/nav-bar';
+export { default as NoticeBar } from 'antd-mobile/lib/notice-bar';
+
+export { default as Pagination } from 'antd-mobile/lib/pagination';
+export { default as Picker } from 'antd-mobile/lib/picker';
+export { default as PickerView } from 'antd-mobile/lib/picker-view';
+export { default as Popover } from 'antd-mobile/lib/popover';
+export { default as Popup } from 'antd-mobile/lib/popup';
+export { default as Progress } from 'antd-mobile/lib/progress';
+
+export { default as Radio } from 'antd-mobile/lib/radio';
+export { default as RefreshControl } from 'antd-mobile/lib/refresh-control';
+export { default as Result } from 'antd-mobile/lib/result';
+export { default as SearchBar } from 'antd-mobile/lib/search-bar';
+export { default as SegmentedControl } from 'antd-mobile/lib/segmented-control';
+export { default as Slider } from 'antd-mobile/lib/slider';
+export { default as Range } from 'antd-mobile/lib/range';
+export { default as createTooltip } from 'antd-mobile/lib/create-tooltip/index.web';
+export { default as Stepper } from 'antd-mobile/lib/stepper';
+export { default as Steps } from 'antd-mobile/lib/steps';
+export { default as SwipeAction } from 'antd-mobile/lib/swipe-action';
+export { default as Switch } from 'antd-mobile/lib/switch';
+export { default as TabBar } from 'antd-mobile/lib/tab-bar';
+export { default as Table } from 'antd-mobile/lib/table';
+export { default as Tabs } from 'antd-mobile/lib/tabs';
+export { default as Tag } from 'antd-mobile/lib/tag';
+export { default as Text } from 'antd-mobile/lib/text';
+export { default as TextareaItem } from 'antd-mobile/lib/textarea-item';
+export { default as Toast } from 'antd-mobile/lib/toast';
+export { default as View } from 'antd-mobile/lib/view';
+export { default as WhiteSpace } from 'antd-mobile/lib/white-space';
+export { default as WingBlank } from 'antd-mobile/lib/wing-blank';
+
+export { default as LocaleProvider } from 'antd-mobile/lib/locale-provider';

--- a/ts-mapping/web/tsconfig.json
+++ b/ts-mapping/web/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "baseUrl": "../",
+    "paths": {
+      "antd-mobile": ["./node_modules/antd-mobile/lib"],
+      "antd-mobile/lib/*": ["./node_modules/antd-mobile/lib/*/index.web"]
+    }
+  }
+}

--- a/ts-mapping/web/web.tsx
+++ b/ts-mapping/web/web.tsx
@@ -1,0 +1,17 @@
+import { Card, List } from 'antd-mobile'
+import Flex from 'antd-mobile/lib/flex'
+
+const style = { color: 'white' }
+
+const card = (
+  <Card
+    onClick={() => { }}
+  />
+)
+
+const list = () => (
+  <List
+    style={style}
+    onClick={() => { }}
+  />
+)


### PR DESCRIPTION
https://github.com/ant-design/ant-design-mobile/issues/1557

Hey @paranoidjk . Checkout this and open in vscode. Hold ⌘ then click `List` `Flex` in `native.tsx` `web.tsx`. The editor jump to the right `.d.ts`. files.

ref [https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping)